### PR TITLE
Add optional borsh support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "normdecimal"
 description = "Always normal decimal numbers"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Konstantin Stepanov <me@kstep.me>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+borsh = ["rust_decimal/borsh", "dep:borsh"]
+
 [dependencies]
 rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
+borsh = { version = "0.9", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,11 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{fmt, ops::*, str::FromStr};
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
+
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Clone, Copy)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[serde(transparent)]
 pub struct NormDecimal(Decimal);
 


### PR DESCRIPTION
Add optional [borsh](https://borsh.io) support for Serialization/Deserialization of normdecimal