### PR TITLE
implement DerefMut for NormDecimal and fix borsh dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "normdecimal"
 description = "Always normal decimal numbers"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Konstantin Stepanov <me@kstep.me>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ keywords = ["decimal", "decnumber"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-borsh = ["rust_decimal/borsh", "dep:borsh"]
+borsh = ["dep:borsh", "rust_decimal/borsh"]
 sqlx = ["dep:sqlx"]
 postgres = ["sqlx/postgres"]
 
 [dependencies]
-rust_decimal = "1"
+rust_decimal = "1.28.1"
 serde = { version = "1", features = ["derive"] }
 borsh = { version = "0.10", optional = true }
 sqlx = { version = "0.6", optional = true, features = ["runtime-tokio-native-tls", "decimal"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,12 @@ impl Deref for NormDecimal {
     }
 }
 
+impl DerefMut for NormDecimal {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl fmt::Display for NormDecimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)


### PR DESCRIPTION
- `NormDecimal` missing `DerefMut` trait
- There are issue between rust-decimal and borsh versions: `rust-decimal 1.28.0` depends on `borsh 0.9.3` but `rust-decimal 1.28.1` depends on `borsh 0.10`. I have set `rust-decimal` requirements to `1.28.1`